### PR TITLE
Use the same tcl icon for expect scripts

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -259,6 +259,7 @@
     ("swift"          nerd-icons-devicon "nf-dev-swift"          :face nerd-icons-green)
 
     ("tcl"            nerd-icons-mdicon "nf-md-feather"          :face nerd-icons-dred)
+    ("exp"            nerd-icons-mdicon "nf-md-feather"          :face nerd-icons-dred)
 
     ("tf"             nerd-icons-mdicon "nf-md-terraform"        :face nerd-icons-purple-alt)
     ("tfvars"         nerd-icons-mdicon "nf-md-terraform"        :face nerd-icons-purple-alt)


### PR DESCRIPTION
[Expect](https://www.man7.org/linux/man-pages/man1/expect.1.html) is a program that "talks" to other interactive programs according to a script. Expectk is a mixture of Expect and Tk.  It behaves just like Expect and Tk's wish. Expect can also be used directly in C or C++ (that is, without Tcl).

Emacs already opens expect files in Tcl-mode by default for font lock. 

<img width="601" alt="Screenshot 2023-08-16 at 5 46 47 PM" src="https://github.com/rainstormstudio/nerd-icons.el/assets/12916795/5b0249e6-ccd1-43d0-9bb9-858339d14ec2">

I noticed, that unlick TCL files I open , expect files didn't have an icon attached to it on the modeline. This PR aims to solve it. 
![Screenshot 2023-08-16 at 5 47 57 PM](https://github.com/rainstormstudio/nerd-icons.el/assets/12916795/6a943f87-2102-4614-af81-18649e2a17c9)
