### PR TITLE
Only match the non-directory part of file name

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1035,8 +1035,9 @@ inserting functions."
 ARG-OVERRIDES should be a plist containining `:height',
 `:v-adjust' or `:face' properties like in the normal icon
 inserting functions."
-  (let* ((ext (file-name-extension file))
-         (icon (or (nerd-icons-match-to-alist file nerd-icons-regexp-icon-alist)
+  (let* ((name (file-name-nondirectory file))
+         (ext (file-name-extension name))
+         (icon (or (nerd-icons-match-to-alist name nerd-icons-regexp-icon-alist)
                    (and ext
                         (cdr (assoc (downcase ext)
                                     nerd-icons-extension-icon-alist)))


### PR DESCRIPTION
The context here is I have some code which does completion on relative paths so stuff like `../../ab/cd.el` etc, because of  `("^\\." nerd-icons-octicon "nf-oct-gear")` in `nerd-icons-regexp-icon-alist` all relative path end up with the gear icon. As far as I can tell, the regexps in that alist seemed designed to match the non-directory part of filename and not the whole path and hence this patch.