### PR TITLE
Fix nerd icons charset range

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1220,7 +1220,7 @@ pause for DURATION seconds between printing each character."
 (defun nerd-icons-set-font (&optional font-family frame)
   "Modify nerd font charsets to use FONT-FAMILY for FRAME."
   (let ((font-f (or font-family nerd-icons-font-family))
-        (charsets '((#xe5fa . #xe631)  ;; Seti-UI + Custom
+        (charsets '((#xe5fa . #xe6b3)  ;; Seti-UI + Custom
                     (#xe700 . #xe7c5)  ;; Devicons
                     (#xf000 . #xf2e0)  ;; Font Awesome
                     (#xe200 . #xe2a9)  ;; Font Awesome Extension

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1220,17 +1220,17 @@ pause for DURATION seconds between printing each character."
 (defun nerd-icons-set-font (&optional font-family frame)
   "Modify nerd font charsets to use FONT-FAMILY for FRAME."
   (let ((font-f (or font-family nerd-icons-font-family))
-        (charsets '((#xe5fa . #xe6b3)  ;; Seti-UI + Custom
+        (charsets '((#xe5fa . #xe6b2)  ;; Seti-UI + Custom
                     (#xe700 . #xe7c5)  ;; Devicons
                     (#xf000 . #xf2e0)  ;; Font Awesome
                     (#xe200 . #xe2a9)  ;; Font Awesome Extension
                     (#xf500 . #xfd46) (#xf0001 . #xf1af0) ;; Material Design Icons
                     (#xe300 . #xe3eb)  ;; Weather
-                    (#xf400 . #xf4a9) #x2665 #x26A1  ;; Octicons
+                    (#xf400 . #xf4a8) #x2665 #x26a1 #xf27c  ;; Octicons
                     (#xe0a0 . #xe0a2) (#xe0b0 . #xe0b3)  ;; Powerline Symbols
-                    #xe0a3 (#xe0b4 . #xe0c8) #xe0ca (#xe0cc . #xe0d4)  ;; Powerline Extra Symbols
+                    #xe0a3 (#xe0b4 . #xe0c8) (#xe0cc . #xe0d2) #xe0d4  ;; Powerline Extra Symbols
                     (#x23fb . #x23fe) #x2b58  ;; IEC Power Symbols
-                    (#xf300 . #xf32d)  ;; Font Logos
+                    (#xf300 . #xf372)  ;; Font Logos
                     (#xe000 . #xe00a)  ;; Pomicons
                     (#xea60 . #xebeb))))  ;; Codicons
     (cl-loop for charset in charsets do


### PR DESCRIPTION
When using `nerd-icons-set-font`, I found that some icons not setup by this function.

See: https://github.com/ryanoasis/nerd-fonts/blob/master/bin/scripts/test-fonts.sh