### PR TITLE
ci: Exclude macos tests below 28.x

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,11 @@ jobs:
         - os: macos-latest
           emacs-version: snapshot
           experimental: true
+        exclude:
+          - os: macos-latest
+            emacs-version: 26.3
+          - os: macos-latest
+            emacs-version: 27.2
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
For https://github.com/rainstormstudio/nerd-icons.el/pull/78#issuecomment-2128439159.