### PR TITLE
chore: add icon for eat-mode

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -592,6 +592,7 @@
     (rjsx-mode                         nerd-icons-devicon "nf-dev-javascript"         :face nerd-icons-cyan-alt)
     (term-mode                         nerd-icons-devicon "nf-dev-terminal")
     (vterm-mode                        nerd-icons-devicon "nf-dev-terminal")
+    (eat-mode                          nerd-icons-devicon "nf-dev-terminal")
     (eshell-mode                       nerd-icons-devicon "nf-dev-terminal"           :face nerd-icons-purple)
     (magit-refs-mode                   nerd-icons-devicon "nf-dev-git_branch"         :face nerd-icons-red)
     (magit-process-mode                nerd-icons-octicon "nf-oct-mark_github")


### PR DESCRIPTION
Add mode icon for [Eat](https://codeberg.org/akib/emacs-eat)