### PR TITLE
feat(filetypes): Add ClojureDart filetype

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -213,6 +213,7 @@
     ("el"             nerd-icons-sucicon "nf-custom-emacs"       :face nerd-icons-purple)
     ("clj"            nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-blue)
     ("cljc"           nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-blue)
+    ("cljd"           nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-green)
     ("cljs"           nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-lyellow)
     ("coffee"         nerd-icons-devicon "nf-dev-coffeescript"   :face nerd-icons-maroon)
     ("iced"           nerd-icons-devicon "nf-dev-coffeescript"   :face nerd-icons-lmaroon)


### PR DESCRIPTION
Why?:
- ClojureDart is a new and coming Clojure dialect whose filetypes are currently not recognized by nerd-icons.el.

This change addresses the need by:
- Add definition for ClojureDart (.cljd) filetypes