### PR TITLE
feat: add dart-ts-mode icon

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -783,6 +783,7 @@
     (japanese-plain-TeX-mode           nerd-icons-sucicon "nf-seti-tex"               :face nerd-icons-lred)
     (japanese-LaTeX-mode               nerd-icons-sucicon "nf-seti-tex"               :face nerd-icons-lred)
     (dart-mode                         nerd-icons-devicon "nf-dev-dart"               :face nerd-icons-blue)
+    (dart-ts-mode                      nerd-icons-devicon "nf-dev-dart"               :face nerd-icons-blue)
     (fsharp-mode                       nerd-icons-devicon "nf-dev-fsharp"             :face nerd-icons-blue)
     (asm-mode                          nerd-icons-sucicon "nf-seti-asm"               :face nerd-icons-blue)
     (fasm-mode                         nerd-icons-sucicon "nf-seti-asm"               :face nerd-icons-blue)


### PR DESCRIPTION
Add an icon for the Dart tree-sitter mode found [here](https://github.com/50ways2sayhard/dart-ts-mode).