### PR TITLE
feat: add go-work-ts-mode icon

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -685,6 +685,7 @@
     (go-dot-mod-mode                   nerd-icons-sucicon "nf-seti-config"            :face nerd-icons-blue-alt)
     (go-mod-ts-mode                    nerd-icons-sucicon "nf-seti-config"            :face nerd-icons-blue-alt)
     (go-dot-work-mode                  nerd-icons-sucicon "nf-seti-config"            :face nerd-icons-blue-alt)
+    (go-work-ts-mode                   nerd-icons-sucicon "nf-seti-config"            :face nerd-icons-blue-alt)
     (graphql-mode                      nerd-icons-sucicon "nf-seti-graphql"           :face nerd-icons-dpink)
     ;; (matlab-mode                    nerd-icons-fileicon "matlab"                   :face nerd-icons-orange)
     (nix-mode                          nerd-icons-mdicon "nf-md-nix"                  :face nerd-icons-blue)


### PR DESCRIPTION
Add an icon for `go-work-ts-mode`, a mode for working with Go workspace files introduced by yours truly in https://github.com/emacs-mirror/emacs/commit/aade1b707c6b4932ed023f387d49324c6a7123eb.