### PR TITLE
Change order of file name to icon-alist checks

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1126,10 +1126,10 @@ ARG-OVERRIDES should be a plist containining `:height',
 inserting functions."
   (let* ((name (file-name-nondirectory file))
          (ext (file-name-extension name))
-         (icon (or (nerd-icons-match-to-alist name nerd-icons-regexp-icon-alist)
-                   (and ext
+         (icon (or (and ext
                         (cdr (assoc (downcase ext)
                                     nerd-icons-extension-icon-alist)))
+                   (nerd-icons-match-to-alist name nerd-icons-regexp-icon-alist)                   
                    nerd-icons-default-file-icon))
          (args (cdr icon)))
     (when arg-overrides (setq args (append `(,(car args)) arg-overrides (cdr args))))


### PR DESCRIPTION
With dired I found that some python files named merge_*.py were displayed with the vc branch or merge icon instead of the python icon. I propose to change the order of the file name matching checks to first check the file extension, then check the file basename. IMHO the file extension should take precedence over the file basename.