### PR TITLE
add contrib package in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -119,6 +119,7 @@ Please check [[https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-
 + [[https://github.com/LuigiPiucco/nerd-icons-corfu][nerd-icons-corfu]]
 + [[https://github.com/alexluigit/dirvish][dirvish]]
 + [[https://github.com/seagle0128/doom-modeline][doom-modeline]]
++ [[https://github.com/grolongo/nerd-icons-mode-line][nerd-icons-mode-line]]
 
 ** use nerd-icons with dirvish
 sample configuration:


### PR DESCRIPTION
Hey, I made this small package for nerd-icons and thought it would fit in your
readme. It basically adds an icon in the mode line, for those who don't really
want to replace it entirely with doom modeline for example.