### PR TITLE
perf: Add caching to nerd-icons-match-to-alist for significant performance improvement

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1033,9 +1033,15 @@
          (auto-mode (nerd-icons-match-to-alist file auto-mode-alist)))
     (eq major-mode auto-mode)))
 
+(defvar nerd-icons--file-cache (make-hash-table :test 'equal)
+  "Cache for file extension to mode mapping.")
+
 (defun nerd-icons-match-to-alist (file alist)
   "Match FILE against an entry in ALIST using `string-match'."
-  (cdr (cl-find-if (lambda (it) (string-match (car it) file)) alist)))
+  (or (gethash file nerd-icons--file-cache)
+      (puthash file
+               (cdr (cl-find-if (lambda (it) (string-match (car it) file)) alist))
+               nerd-icons--file-cache)))
 
 (defun nerd-icons-dir-is-submodule (dir)
   "Checker whether or not DIR is a git submodule."


### PR DESCRIPTION
Add caching to `nerd-icons-match-to-alist` for significant performance improvement.

Before:
```
70405   5%            - nerd-icons-icon-for-buffer
70206   5%             - nerd-icons--icon-info-for-buffer
57285   4%                    - nerd-icons-match-to-alist
44519   3%                            string-match
```

After:
```
2801   0%            - nerd-icons-icon-for-buffer
2801   0%             - nerd-icons--icon-info-for-buffer
```