### PR TITLE
Remove broken web-mode support

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -726,8 +726,7 @@
     (paradox-menu-mode                 nerd-icons-faicon "nf-fa-archive"              :face nerd-icons-silver)
     (Custom-mode                       nerd-icons-codicon "nf-cod-settings")
 
-    ;; Special matcher for Web Mode based on the `web-mode-content-type' of the current buffer
-    (web-mode                          nerd-icons--web-mode-icon)
+    (web-mode                          nerd-icons-devicon "nf-dev-html5")
 
     (fundamental-mode                  nerd-icons-sucicon "nf-custom-emacs"           :face nerd-icons-dsilver)
     (special-mode                      nerd-icons-sucicon "nf-custom-emacs"           :face nerd-icons-yellow)
@@ -1293,34 +1292,6 @@ icon."
   "Get an icon for a WEATHER status."
   (let ((icon (nerd-icons-match-to-alist weather nerd-icons-weather-icon-alist)))
     (if icon (apply (car icon) (cdr icon)) weather)))
-
-;; For `web-mode'
-(defun nerd-icons--web-mode-icon (&rest arg-overrides)
-  "Get icon for a `web-mode' buffer with ARG-OVERRIDES."
-  (nerd-icons--web-mode arg-overrides))
-(defun nerd-icons--web-mode-icon-family ()
-  "Get icon family for a `web-mode' buffer."
-  (nerd-icons--web-mode t))
-
-(defvar web-mode-content-type)          ; external
-(defun nerd-icons--web-mode (&optional arg-overrides)
-  "Return icon or FAMILY for `web-mode' based on `web-mode-content-type'.
-Providing ARG-OVERRIDES will modify the creation of the icon."
-  (let ((non-nil-args (cl-reduce (lambda (acc it) (if it (append acc (list it)) acc))
-                                 arg-overrides :initial-value '())))
-    (cond
-     ((equal web-mode-content-type "jsx")
-      (apply 'nerd-icons-devicon (append '("javascript") non-nil-args)))
-     ((equal web-mode-content-type "javascript")
-      (apply 'nerd-icons-devicon (append '("javascript") non-nil-args)))
-     ((equal web-mode-content-type "json")
-      (apply 'nerd-icons-devicon (append '("nf-dev-less") non-nil-args)))
-     ((equal web-mode-content-type "xml")
-      (apply 'nerd-icons-faicon (append '("nf-fa-file_code_o") non-nil-args)))
-     ((equal web-mode-content-type "css")
-      (apply 'nerd-icons-devicon (append '("nf-dev-css3") non-nil-args)))
-     (t
-      (apply 'nerd-icons-devicon (append '("nf-dev-html5") non-nil-args))))))
 
 (eval-and-compile
   (defun nerd-icons--function-name (name)


### PR DESCRIPTION
`nerd-icons--web-mode-icon` is supposed to lookup the correct icon for a web-mode buffer, but it
doesn't work in practice:

1. It's requires the web-mode buffer to be current (it relies on buffer-local variables) but that's rarely the case (e.g., when called from `nerd-icons-icon-for-mode`).

2. `nerd-icons-icon-for-mode` caches the icon, so the chosen icon will be correct the first time only (and then, only correct subject to 1).

Fortunately, there's a better option: use `nerd-icons-icon-for-buffer`. That will try to derive an icon from the file-name first before falling back on the mode.

This patch removes this support as it's broken and there's a working alternative.

It might make sense to extend `nerd-icons-icon-for-buffer` to implement this behavior (I intend to submit a PR for EXWM to this effect later) but I'm not convinced it's worth it in this case (easier to simply rely on the file-name).