### PR TITLE
Make nerd-icons-icon-for-buffer generic

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -5,7 +5,7 @@
 ;; Author: Hongyu Ding <rainstormstudio@yahoo.com>, Vincent Zhang <seagle0128@gmail.com>
 ;; Keywords: lisp
 ;; Version: 0.1.0
-;; Package-Requires: ((emacs "24.3"))
+;; Package-Requires: ((emacs "25.1"))
 ;; URL: https://github.com/rainstormstudio/nerd-icons.el
 ;; Keywords: convenient, lisp
 
@@ -1250,7 +1250,7 @@ inserting functions."
     (apply (car icon) args)))
 
 ;;;###autoload
-(defun nerd-icons-icon-for-buffer (&rest arg-overrides)
+(cl-defgeneric nerd-icons-icon-for-buffer (&rest arg-overrides)
   "Get the formatted icon for the current buffer.
 
 ARG-OVERRIDES should be a plist containing `:height',


### PR DESCRIPTION
This makes it possible to override the per-buffer logic, e.g., based on the major mode, buffer-local variables, etc.

E.g., for EXWM:

```elisp
(cl-defmethod nerd-icons-icon-for-buffer (&context (major-mode exwm-mode) &rest props)
  (let ((base-icon (apply #'nerd-icons-icon-for-mode 'exwm-mode props)))
    ;; NOTE: Don't scale/move the image; it's positioned/scaled relative to the text.
    (if-let* ((image (exwm-icon nil :scale 1.0 :height '(1.0 . ch) :ascent 'center)))
        ;; Merge the image with the existing display property.
        (let ((prop (get-text-property 0 'display base-icon)))
          (unless (listp (car prop)) (setq prop (list prop)))
          (propertize base-icon 'display (cons image prop)))
      base-icon)))
```

This would also make it possible to implement the web-mode support correctly, although I think the default behavior of `nerd-icons-icon-for-buffer` is probably good enough here.