### PR TITLE
Multiple improvements/fixes to icon caching

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1072,12 +1072,7 @@
         ;; `set-auto-mode--last' (on Emacs >= 29).
         (if-let* ((last-auto-mode (bound-and-true-p set-auto-mode--last)))
             (cdr last-auto-mode)
-          (nerd-icons--auto-mode-lookup (file-name-nondirectory fname))))))
-
-(defun nerd-icons--auto-mode-lookup (file)
-  "Return the mode-setting function associated with FILE via `auto-mode-alist'.
-NOTE: The mode-setting function may not be the same as the mode itself."
-  (nerd-icons-match-to-alist file auto-mode-alist))
+          (nerd-icons-match-to-alist (file-name-nondirectory fname) auto-mode-alist)))))
 
 (defun nerd-icons-match-to-alist (file alist)
   "Match FILE against an entry in ALIST using `string-match'."
@@ -1301,7 +1296,6 @@ icon."
 (nerd-icons-cache #'nerd-icons-icon-for-extension)
 (nerd-icons-cache #'nerd-icons-icon-for-mode)
 (nerd-icons-cache #'nerd-icons-icon-for-url)
-(nerd-icons-cache #'nerd-icons--auto-mode-lookup)
 
 ;; Weather icons
 (defun nerd-icons-icon-for-weather (weather)

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1065,14 +1065,16 @@
 
 (defun nerd-icons-auto-mode-match? ()
   "Whether or not the buffer's `major-mode' matches its entry in `auto-mode-alist'."
-  (when-let* ((fname (buffer-file-name)))
+  (when-let* ((fname (buffer-file-name))
+              (modefn (nerd-icons-match-to-alist (file-name-nondirectory fname) auto-mode-alist)))
     (eq major-mode
         ;; When set-auto-mode sets the mode and the resulting `major-mode' variable doesn't
         ;; match the entry in `auto-mode-alist', it records the actual mode set in
         ;; `set-auto-mode--last' (on Emacs >= 29).
-        (if-let* ((last-auto-mode (bound-and-true-p set-auto-mode--last)))
+        (if-let* ((last-auto-mode (bound-and-true-p set-auto-mode--last))
+                  ((eq modefn (car last-auto-mode))))
             (cdr last-auto-mode)
-          (nerd-icons-match-to-alist (file-name-nondirectory fname) auto-mode-alist)))))
+          modefn))))
 
 (defun nerd-icons-match-to-alist (file alist)
   "Match FILE against an entry in ALIST using `string-match'."

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1280,17 +1280,18 @@ icon."
   (unless (get func 'nerd-icons--cached)
     (let ((cache (make-hash-table :test #'equal
                                   :size nerd-icons--cache-limit))
-          (orig-fn (symbol-function func)))
+          (orig-fn (symbol-function func))
+          (unset (make-symbol "unset")))
       (fset func
             (lambda (&rest args)
-              (or (gethash args cache)
-                  (progn
-                    (when (> (hash-table-count cache)
-                             nerd-icons--cache-limit)
-                      (clrhash cache))
-                    (puthash args (apply orig-fn args) cache)))))))
-
-  (put func 'nerd-icons--cached t))
+              (let ((value (gethash args cache unset)))
+                (when (eq value unset)
+                  (when (> (hash-table-count cache)
+                           nerd-icons--cache-limit)
+                    (clrhash cache))
+                  (setq value (puthash args (apply orig-fn args) cache)))
+                value))))
+    (put func 'nerd-icons--cached t)))
 
 (nerd-icons-cache #'nerd-icons-icon-for-dir)
 (nerd-icons-cache #'nerd-icons-icon-for-file)

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1074,10 +1074,7 @@
 
 (defun nerd-icons-match-to-alist (file alist)
   "Match FILE against an entry in ALIST using `string-match'."
-  (or (gethash file nerd-icons--file-cache)
-      (puthash file
-               (cdr (cl-find-if (lambda (it) (string-match (car it) file)) alist))
-               nerd-icons--file-cache)))
+  (cdr (assoc file alist #'string-match)))
 
 (defun nerd-icons-dir-is-submodule (dir)
   "Checker whether or not DIR is a git submodule."

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1302,6 +1302,8 @@ icon."
   (when-let* ((icon (nerd-icons-match-to-alist weather nerd-icons-weather-icon-alist)))
     (apply (car icon) (cdr icon))))
 
+(nerd-icons-cache #'nerd-icons-icon-for-weather)
+
 (eval-and-compile
   (defun nerd-icons--function-name (name)
     "Get the symbol for an icon function name for icon set NAME."


### PR DESCRIPTION
1. Optimization: Cache `nil` (negative) results.
2. Fix: Remove the caching from `nerd-icons-match-to-alist` because it was caching results from different alists (mixing icons and mode-names). The next few commits add this back.
3. Optimization: Add back caching to `nerd-icons-icon-for-weather` (explicitly this time, instead of through `nerd-icons-match-to-alist`.
4. Fix: Make `nerd-icons-auto-mode-match?` work with tree-sitter buffers (well, all buffers where the entry in `auto-mode-alist` doesn't exactly match the resulting `major-mode`).
5. Optimization: Add back a cache to `nerd-icons-auto-mode-match?`.