### PR TITLE
Use separate caches for different alists

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1066,8 +1066,13 @@
 (defun nerd-icons-auto-mode-match? (&optional file)
   "Whether or not FILE's `major-mode' match against its `auto-mode-alist'."
   (let* ((file (or file (buffer-file-name) (buffer-name)))
-         (auto-mode (nerd-icons-match-to-alist file auto-mode-alist)))
+         (auto-mode (nerd-icons--auto-mode-lookup (file-name-nondirectory file))))
     (eq major-mode auto-mode)))
+
+(defun nerd-icons--auto-mode-lookup (file)
+  "Return the mode-setting function associated with FILE via `auto-mode-alist'.
+NOTE: The mode-setting function may not be the same as the mode itself."
+  (nerd-icons-match-to-alist file auto-mode-alist))
 
 (defun nerd-icons-match-to-alist (string alist)
   "Match STRING against an entry in ALIST using `string-match'."
@@ -1291,6 +1296,7 @@ icon."
 (nerd-icons-cache #'nerd-icons-icon-for-extension)
 (nerd-icons-cache #'nerd-icons-icon-for-mode)
 (nerd-icons-cache #'nerd-icons-icon-for-url)
+(nerd-icons-cache #'nerd-icons--auto-mode-lookup)
 
 ;; Weather icons
 (defun nerd-icons-icon-for-weather (weather)


### PR DESCRIPTION
Previously, nerd-icons used a single combined cache for `auto-mode-alist`, `nerd-icons-dir-icon-alist`, `nerd-icons-regexp-icon-alist`, `nerd-icons-url-alist`, and `nerd-icons-weather-icon-alist` via the caching built-in to `nerd-icons-match-to-alist`. Unfortunately, this could lead to incorrect results using a cached return value from one function as the return value of another.

This PR:

1. Removes this shared cache.
2. Adds back caching to `nerd-icons-icon-for-weather` and `nerd-icons-auto-mode-match?`.