### PR TITLE
Fix regexp for Babel config files

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -635,7 +635,7 @@
     ("^webpack"                nerd-icons-devicon "nf-dev-webpack"           :face nerd-icons-lblue)
     ("^\\.?eslint"             nerd-icons-devicon "nf-dev-eslint"            :face nerd-icons-lblue)
     ("^\\.?prettier"           nerd-icons-sucicon "nf-custom-prettier"       :face nerd-icons-silver)
-    ("^\\.?babel"              nerd-icons-sucicon "nf-seti-babel"            :face nerd-icons-yellow)
+    ("\\`babel\\.config.*"     nerd-icons-sucicon "nf-seti-babel"            :face nerd-icons-yellow)
     ("^vite.config"            nerd-icons-devicon "nf-dev-vitest"            :face nerd-icons-yellow)
     ("^vitest"                 nerd-icons-devicon "nf-dev-vitest"            :face nerd-icons-yellow)
     ("^\\.?jest"               nerd-icons-devicon "nf-dev-jest"              :face nerd-icons-lred)


### PR DESCRIPTION
* nerd-icons.el (nerd-icons-regexp-icon-alist): Fix regexp for Babel configuration files which can be 'babel.config.*', with the following extensions: .json, .js, .cjs, .mjs and .cts acc. to: https://babeljs.io/docs/config-files

Currently, if you have a file like `babel-german.el`, this is what you see in the modeline (assuming `doom-modeline` is installed):
<img width="205" height="24" alt="icon" src="https://github.com/user-attachments/assets/a3e000b7-9499-45d8-a0e8-442d19364d38" />

To reproduce with `emacs -Q`, eval this form and open a file `babel-german.el`:
```
(progn
  (package-initialize t)
  (package-activate 'doom-modeline)
  (use-package doom-modeline
    :init
    (doom-modeline-mode 1)))
```


This patch fixes the issue by adjusting the regexp for Babel config files acc. to [this page](https://babeljs.io/docs/config-files).