### PR TITLE
fix: update nerd-icons-set-font codepoint ranges to Nerd Fonts 3.4.0

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1429,19 +1429,18 @@ pause for DURATION seconds between printing each character."
 (defun nerd-icons-set-font (&optional font-family frame)
   "Modify nerd font charsets to use FONT-FAMILY for FRAME."
   (let ((font-f (or font-family nerd-icons-font-family))
-        (charsets '((#xe5fa . #xe6b2)  ;; Seti-UI + Custom
-                    (#xe700 . #xe7c5)  ;; Devicons
-                    (#xf000 . #xf2e0)  ;; Font Awesome
+        (charsets '((#xe5fa . #xe6b9)  ;; Seti-UI + Custom
+                    (#xe700 . #xe8ef)  ;; Devicons
+                    (#xed00 . #xf2ff)  ;; Font Awesome
                     (#xe200 . #xe2a9)  ;; Font Awesome Extension
                     (#xf500 . #xfd46) (#xf0001 . #xf1af0) ;; Material Design Icons
-                    (#xe300 . #xe3eb)  ;; Weather
-                    (#xf400 . #xf4a8) #x2665 #x26a1 #xf27c  ;; Octicons
-                    (#xe0a0 . #xe0a2) (#xe0b0 . #xe0b3)  ;; Powerline Symbols
-                    #xe0a3 (#xe0b4 . #xe0c8) (#xe0cc . #xe0d2) #xe0d4  ;; Powerline Extra Symbols
+                    (#xe300 . #xe3e3)  ;; Weather
+                    (#xf400 . #xf533) #x2665 #x26a1  ;; Octicons
+                    (#xe0a0 . #xe0a3) (#xe0b0 . #xe0d7)  ;; Powerline Symbols + Extra
                     (#x23fb . #x23fe) #x2b58  ;; IEC Power Symbols
-                    (#xf300 . #xf372)  ;; Font Logos
+                    (#xf300 . #xf381)  ;; Font Logos
                     (#xe000 . #xe00a)  ;; Pomicons
-                    (#xea60 . #xebeb))))  ;; Codicons
+                    (#xea60 . #xec1e))))  ;; Codicons
     (cl-loop for charset in charsets do
              (set-fontset-font
               (frame-parameter nil 'font)


### PR DESCRIPTION
## Summary

`nerd-icons-set-font` registers PUA codepoint ranges with `set-fontset-font` so that Nerd Font glyphs render correctly even when the default font is not a Nerd Font. The hardcoded ranges were based on an older Nerd Fonts version and no longer cover all icons shipped in the data files.

For example, `nf-dev-microsoftsqlserver` (U+E82E) falls outside the old Devicons range `#xE700..#xE7C5`, causing it to render with the wrong font.

This PR updates all ranges to match the official codepoint assignments from [Nerd Fonts 3.4.0](https://github.com/ryanoasis/nerd-fonts/tree/master/bin/scripts/lib):

| Glyph Set | Old Range | New Range | Source |
|---|---|---|---|
| Seti-UI + Custom | E5FA..E6B2 | E5FA..E6B9 | `i_seti.sh` |
| Devicons | E700..E7C5 | E700..E8EF | `i_dev.sh` |
| Font Awesome | F000..F2E0 | ED00..F2FF | `i_fa.sh` |
| Weather | E300..E3EB | E300..E3E3 | `i_weather.sh` |
| Octicons | F400..F4A8 | F400..F533 | `i_oct.sh` |
| Powerline + Extra | scattered sub-ranges | E0A0..E0A3, E0B0..E0D7 | `i_ple.sh` |
| Font Logos | F300..F372 | F300..F381 | `i_logos.sh` |
| Codicons | EA60..EBEB | EA60..EC1E | `i_cod.sh` |

Ranges that were already correct (FA Extension, Material Design Icons, IEC Power, Pomicons) are unchanged.

@seagle0128 