### PR TITLE
Add the possibility to provide a specific path on Windows

### DIFF
--- a/README.org
+++ b/README.org
@@ -25,21 +25,21 @@ To automatically install =Symbols Nerd Font Mono=, you can use this elisp in you
 
 #+BEGIN_SRC emacs-lisp
 ;; Linux/macOS/BSDs
-  (when (member system-type '(gnu gnu/linux gnu/kfreebsd darwin))
-    (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
-      (nerd-icons-install-fonts t)))
+(when (member system-type '(gnu gnu/linux gnu/kfreebsd darwin))
+  (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+    (nerd-icons-install-fonts t)))
 
 ;; Windows
-  (when (string-equal system-type 'windows-nt)
-    (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
-      (nerd-icons-install-fonts "c:/Users/username/Desktop/")))
+(when (string-equal system-type 'windows-nt)
+  (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+    (nerd-icons-install-fonts "c:/Users/username/Desktop/")))
 
 ;; All-in-one
 ;; This will install in the default fonts folder for Linux/macOS/BSDs
 ;; (same as “t”), but for Windows this will download to the specified
 ;; folder
-  (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
-    (nerd-icons-install-fonts "c:/Users/username/Desktop/"))
+(unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+  (nerd-icons-install-fonts "c:/Users/username/Desktop/"))
 #+END_SRC
 
 * Usage

--- a/README.org
+++ b/README.org
@@ -21,6 +21,27 @@ Please go to [[https://www.nerdfonts.com/][Nerd Fonts website]] and get a Nerd f
 
 If the Nerd Font you installed does not display correctly (e.g. appear cut off), it is recommended to use =Symbols Nerd Font Mono= (Symbols Nerd Font). You can use ~M-x nerd-icons-install-fonts~ to install ~Symbols Nerd Font Mono~ for you. Note that for *Windows* you'll need to manually install the font after you used this function.
 
+To automatically install =Symbols Nerd Font Mono=, you can use this elisp in your ~init.el~. On macOS, Linux and BSDs, this will download and install the font directly for you. On Windows, you can specify the folder to download the font to, but you will still have to manually install it after.
+
+#+BEGIN_SRC emacs-lisp
+;; Linux/macOS/BSDs
+  (when (member system-type '(gnu gnu/linux gnu/kfreebsd darwin))
+    (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+      (nerd-icons-install-fonts t)))
+
+;; Windows
+  (when (string-equal system-type 'windows-nt)
+    (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+      (nerd-icons-install-fonts "c:/Users/username/Desktop/")))
+
+;; All-in-one
+;; This will install in the default fonts folder for Linux/macOS/BSDs
+;; (same as “t”), but for Windows this will download to the specified
+;; folder
+  (unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
+    (nerd-icons-install-fonts "c:/Users/username/Desktop/"))
+#+END_SRC
+
 * Usage
 ~nerd-icons~ is on [[https://melpa.org/#/nerd-icons-completion][Melpa]]. You can install it with built-in ~M-x package-install~
 #+begin_src emacs-lisp

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1194,7 +1194,8 @@ string."
 (defun nerd-icons-install-fonts (&optional pfx)
   "Helper function to download and install the latests fonts based on OS.
 The provided Nerd Font is Symbols Nerd Font Mono.
-When PFX is non-nil, ignore the prompt and just install"
+When PFX is non-nil, ignore the prompt and just install.
+On Windows only, when PFX is a path, ignore the prompt and download there."
   (interactive "P")
   (when (or pfx (yes-or-no-p "This will download and install fonts, are you sure you want to do this?"))
     (let* ((url-format "https://raw.githubusercontent.com/rainstormstudio/nerd-icons.el/main/fonts/%s")
@@ -1211,7 +1212,9 @@ When PFX is non-nil, ignore the prompt and just install"
                                 "/Library/Fonts/"
                                 nerd-icons-fonts-subdirectory))))
            (known-dest? (stringp font-dest))
-           (font-dest (or font-dest (read-directory-name "Font installation directory: " "~/"))))
+           (font-dest (or font-dest
+                          (and (stringp pfx) pfx)
+                          (read-directory-name "Font installation directory: " "~/"))))
 
       (unless (file-directory-p font-dest) (mkdir font-dest t))
 


### PR DESCRIPTION
Useful for automation, now one can use something like:

(unless (find-font (font-spec :name "Symbols Nerd Font Mono"))
  (nerd-icons-install-fonts (expand-file-name user-emacs-directory)))

to either install (macOS/Linux/BSD) or download (Windows) the font automatically
from his init.el