### PR TITLE
Add `tab-line-nerd-icons` to Related Packages

### DIFF
--- a/README.org
+++ b/README.org
@@ -141,6 +141,7 @@ Please check [[https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-
 + [[https://github.com/alexluigit/dirvish][dirvish]]
 + [[https://github.com/seagle0128/doom-modeline][doom-modeline]]
 + [[https://github.com/grolongo/nerd-icons-mode-line][nerd-icons-mode-line]]
++ [[https://github.com/lucius-martius/tab-line-nerd-icons][tab-line-nerd-icons]]
 
 ** use nerd-icons with dirvish
 sample configuration:


### PR DESCRIPTION
I haven't updated the package in a while, but mostly because no changes were requested and it just works.

Link to repo: https://github.com/lucius-martius/tab-line-nerd-icons