### PR TITLE
Add nerd-icons-multimodal to related packages and fnl file icon

### DIFF
--- a/README.org
+++ b/README.org
@@ -133,6 +133,7 @@ Please check [[https://github.com/ryanoasis/nerd-fonts/wiki/Glyph-Sets-and-Code-
 
 * Related Packages
 + [[https://github.com/rainstormstudio/nerd-icons-dired][nerd-icons-dired]]
++ [[https://github.com/abougouffa/nerd-icons-multimodal][nerd-icons-multimodal]]
 + [[https://github.com/rainstormstudio/treemacs-nerd-icons][treemacs-nerd-icons]]
 + [[https://github.com/seagle0128/nerd-icons-ivy-rich][nerd-icons-ivy-rich]]
 + [[https://github.com/seagle0128/nerd-icons-ibuffer][nerd-icons-ibuffer]]

--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -234,6 +234,7 @@
     ;; ("hy"             nerd-icons-sucicon "nf-custom-hy"          :face nerd-icons-blue)
     ("el"             nerd-icons-sucicon "nf-custom-emacs"       :face nerd-icons-purple)
     ("eld"            nerd-icons-sucicon "nf-custom-emacs"       :face nerd-icons-purple)
+    ("fnl"            nerd-icons-sucicon "nf-custom-fennel"      :face nerd-icons-green)
     ("clj"            nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-blue)
     ("cljc"           nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-blue)
     ("cljd"           nerd-icons-devicon "nf-dev-clojure"        :face nerd-icons-green)


### PR DESCRIPTION
[nerd-icons-multimodal](https://github.com/abougouffa/nerd-icons-multimodal) is similar to nerd-icons-dired but supports few more packages.
`fnl` file extension is for [Fennel](https://fennel-lang.org/) code.
