### PR TITLE
Disable case-fold-search in nerd-icons-match-to-alist

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1156,7 +1156,8 @@ NOTE: The mode-setting function may not be the same as the mode itself."
 
 (defun nerd-icons-match-to-alist (string alist)
   "Match STRING against an entry in ALIST using `string-match'."
-  (cdr (assoc string alist #'string-match)))
+  (let ((case-fold-search nil))
+    (cdr (assoc string alist #'string-match))))
 
 (defun nerd-icons-dir-is-submodule (dir)
   "Checker whether or not DIR is a git submodule."


### PR DESCRIPTION
I have an issue with matching the wrong icon for files containing "install" in any case. For example, "installments.go".

Before:
<img width="182" height="162" alt="image" src="https://github.com/user-attachments/assets/3bcf2e32-f397-4365-bc60-c697e5a0452c" />

After:
<img width="244" height="149" alt="image" src="https://github.com/user-attachments/assets/0e376e0c-1e54-4e12-a4d3-75d4c55cbb41" />

