### PR TITLE
feat(icons): Add an icon for EWM Surfaces (windows)

### DIFF
--- a/nerd-icons.el
+++ b/nerd-icons.el
@@ -1037,6 +1037,7 @@
     (julia-ts-mode                     nerd-icons-sucicon "nf-seti-julia"                :face nerd-icons-purple)
     (flycheck-error-list               nerd-icons-faicon "nf-fa-list_alt"                :face nerd-icons-lred)
     (exwm-mode                         nerd-icons-flicon "nf-linux-xorg"                 :face nerd-icons-dsilver)
+    (ewm-surface-mode                  nerd-icons-flicon "nf-linux-wayland"              :face nerd-icons-purple)
     (proced-mode                       nerd-icons-codicon "nf-cod-dashboard"             :face nerd-icons-green)
     (bluetooth-mode                    nerd-icons-faicon "nf-fa-bluetooth"               :face nerd-icons-blue)
     (disk-usage                        nerd-icons-faicon "nf-fa-pie_chart"               :face nerd-icons-lred)


### PR DESCRIPTION
EWM is a new Wayland-based window manager for Emacs and ewm-surface-mode is the major mode of its wayland windows. This commit assigns a purple "wayland" icon to all such buffers.